### PR TITLE
fix compile error on windows

### DIFF
--- a/core/include/webpp/http/cookies/cookie.h
+++ b/core/include/webpp/http/cookies/cookie.h
@@ -83,6 +83,7 @@
 
 #include "../../std/unordered_map.h"
 #include "../../std/unordered_set.h"
+#include "../../std/optional.h"
 #include "../../traits/std_traits.h"
 #include "../../utils/charset.h"
 #include "../../utils/strings.h"

--- a/core/include/webpp/utils/ipv4.h
+++ b/core/include/webpp/utils/ipv4.h
@@ -177,7 +177,7 @@ namespace webpp {
             }
 
             stl::size_t slash = third_dot + 1;
-            while (_data[slash] != '/' && slash != len)
+            while (slash != len && _data[slash] != '/')
                 slash++;
 
             auto octet_4 =

--- a/core/include/webpp/utils/uri.h
+++ b/core/include/webpp/utils/uri.h
@@ -3,6 +3,7 @@
 
 #include "../std/map.h"
 #include "../std/vector.h"
+#include "../std/optional.h"
 #include "../traits/traits_concepts.h"
 #include "../validators/validators.h"
 #include "./casts.h"

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -6,6 +6,7 @@ set(EXEC_NAME ${PROJECT_NAME}-bin)
 find_package(Boost COMPONENTS program_options REQUIRED)
 
 add_executable(${EXEC_NAME} ${LIB_SOURCES})
+target_include_directories(${EXEC_NAME} PRIVATE ${Boost_INCLUDE_DIRS})
 target_link_libraries(${EXEC_NAME}
         PRIVATE ${SLIB_NAME}
         PRIVATE ${Boost_LIBRARIES}


### PR DESCRIPTION
Fix two compile errors:
* boost header file not found
* c++ standard header file not found

Fix one crash when running test:
* index out of range on std::string_view 