### PR TITLE
fix: crash on test

### DIFF
--- a/core/include/webpp/http/cookies/cookie.h
+++ b/core/include/webpp/http/cookies/cookie.h
@@ -217,8 +217,7 @@ namespace webpp {
             // todo
             // The _valid may not catch all the validness conditions, so we have
             // to do other validation checks ourselves.
-            if (!_valid)
-                return false;
+            return _valid;
         }
 
         auto const& name() const noexcept {


### PR DESCRIPTION
Function`is_valid()` returns nothing if `_valid` is true which causes crash on **gtest**.