### PR TITLE
AI guidance and MCP tooling for Web++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ CMakeLists.txt.user.*
 # AI stuff
 GEMINI.md
 QWEN.md
-CLAUDE.md
 
 # Some weird script
 .flagged
@@ -151,3 +150,4 @@ crash-*
 # failed patches:
 *.rej
 *.orig
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,17 @@ CMakeLists.txt.user.*
 .Trash-*/
 .qtcreator
 
-# AI stuff
+# Local AI instructions
 GEMINI.md
 QWEN.md
-mcp/node_modules/*
+
+# Repository-local MCP dependencies and generated output
+mcp/node_modules/
+mcp/dist/
+
+# macOS metadata
+.DS_Store
+**/.DS_Store
 
 # Some weird script
 .flagged

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ CMakeLists.txt.user.*
 # AI stuff
 GEMINI.md
 QWEN.md
+mcp/node_modules/*
 
 # Some weird script
 .flagged

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "webpp-project": {
+      "command": "npm",
+      "args": [
+        "--prefix",
+        "${CLAUDE_PROJECT_DIR}/mcp",
+        "start"
+      ],
+      "env": {
+        "PROJECT_ROOT": "${CLAUDE_PROJECT_DIR}"
+      }
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# Web++ AI Contributor Guide
+
+This file is the canonical repository instruction set for AI coding assistants.
+
+## Project Identity
+
+Web++ is an evolving, cross-platform C++ web framework. It provides HTTP abstractions, static and dynamic routing,
+protocol adapters, URI/Unicode processing, traits and allocator support, storage, I/O, and related utilities.
+
+Do not describe or treat this repository as a CMS. The project does not use C++ modules and has no `src/` tree.
+Library implementation is predominantly template- and header-based under `webpp/`, while CMake exposes it as the
+`webpp` static target.
+
+Some prose documentation explicitly says that it is incomplete or outdated. Resolve conflicts in this order:
+
+1. Tests and the current implementation
+2. `CMakeLists.txt`, `CMakePresets.json`, and CI
+3. Component README files
+4. Root-level prose, old examples, and `todo.md`
+
+Never "fix" code merely to make it agree with stale prose.
+
+## Repository Map
+
+- `webpp/`: public library headers and implementation
+  - `http/`, `headers/`, `cgi/`, `fcgi/`, and `protocol/`: HTTP models, routing, and protocol integration
+  - `uri/`, `unicode/`, and `ip/`: standards-sensitive parsing and normalization
+  - `traits/`, `memory/`, and `std/`: customization, allocator propagation, STL aliases/polyfills, and iSTL helpers
+  - `io/`, `async/`, `socket/`, and `concurrency/`: low-level and asynchronous facilities
+  - `storage/`, `db/`, `json/`, `crypto/`, `views/`, and `middleware/`: framework services
+- `tests/`: unit tests (`*_test.cpp`), fuzz targets (`*_fuzz.cpp`), shared test support, and standards fixtures
+- `examples/`: runnable integration examples
+- `benchmarks/`: focused performance experiments; do not treat benchmark code as the public API
+- `sdk/`: the `wpp` and `wsdk` developer tools
+- `cmake/`, `CMakeLists.txt`, and `CMakePresets.json`: build configuration and dependency setup
+- `docs/` and component `README.md` files: project documentation
+- `mcp/`: the repository-local `webpp-project` MCP server for AI assistants
+
+When adding or removing a public header, update `ALL_SOURCES_SHORT` in `webpp/CMakeLists.txt`.
+
+## Architecture and Compatibility
+
+- Preserve the existing namespace and directory boundaries. Put code in the narrowest existing subsystem.
+- Public library code must remain compatible with the target's C++20 baseline. Tests and GCC development builds may
+  use C++23 where their CMake targets already request it. Do not raise the library baseline incidentally.
+- Prefer the project's `webpp::stl` compatibility aliases for standard-library facilities where surrounding code uses
+  them. `webpp::istl` is for Web++ extensions; it must not depend on unrelated Web++ subsystems.
+- Preserve concepts-based contracts, traits customization, allocator propagation, and character-type genericity.
+  Avoid silently replacing them with hard-coded `std::string`, `char`, global allocation, or runtime polymorphism.
+- Preserve compile-time behavior in static routing and other constexpr-heavy code. Use `constexpr`, `consteval`,
+  concepts, `static_assert`, `noexcept`, and `[[nodiscard]]` when the semantics justify them, not as decoration.
+- Avoid adding virtual dispatch or ownership indirection on performance-sensitive paths without an explicit design
+  reason.
+- URI, IDNA, Unicode, HTTP, and IP behavior is standards-sensitive. Consult the relevant component README, fixtures,
+  and nearby tests before changing it. Keep pinned-standard behavior unless the task explicitly requests an update.
+- Do not hand-edit generated Unicode tables or imported fixtures without also preserving their generation/update path.
+
+## Code Style
+
+- Follow `.clang-format` (4-space indentation, 120-column limit) and the applicable `.clang-tidy` configuration.
+- Match naming in the subsystem being edited. The codebase commonly uses `snake_case` for types, functions, variables,
+  and aliases, and PascalCase for concepts and test suites. Do not impose an unrelated naming scheme or perform broad
+  renames.
+- Keep the existing `WEBPP_*` header guards and namespace-closing comments in public headers.
+- Add Doxygen-style documentation for new public APIs when the surrounding interface is documented.
+- Comments and public documentation added to source files must be in English.
+- Keep includes minimal and consistent with nearby headers. Do not bypass `webpp::stl`/polyfill boundaries casually.
+- Prefer focused changes. Do not combine requested work with unrelated cleanup.
+
+## Required Workflow
+
+Use the repository-local `webpp-project` MCP server when it is available:
+
+1. Call `project_overview`, then `git_status`.
+2. Read the relevant implementation, tests, and component docs. `read_project_docs` and `search_project` are preferred
+   for repository discovery.
+3. Inspect the closest analogous implementation before editing.
+4. Make the smallest coherent change and add or update the closest focused test.
+5. Use `list_cmake_presets`, `run_cmake_configure`, `run_cmake_build`, `run_ctest`, `run_test_target`, or
+   `run_all_tests` for verification.
+6. Finish with `git_status` and `git_diff`, and review every changed line.
+
+If the MCP server is unavailable, use the equivalent local commands and explicitly report that fallback. Never skip
+inspection or verification because the MCP connection is missing.
+
+Preserve pre-existing user changes. Build directories, downloaded dependencies, IDE state, and generated artifacts
+must not be committed.
+
+## Build and Test
+
+The development configuration used by CI is:
+
+```sh
+cmake --preset dev-default
+```
+
+For a focused test, derive the target from its source file:
+
+```text
+tests/uri_test.cpp -> test-uri
+tests/http_parser_test.cpp -> test-http-parser
+```
+
+When that focused preset exists, build and run only that target:
+
+```sh
+cmake --build --preset test-uri
+ctest --preset tests -R '^test-uri$' --output-on-failure
+```
+
+`tests/CMakeLists.txt` discovers current test sources, while the focused presets in `CMakePresets.json` are enumerated
+manually and can lag behind. Use MCP `list_test_targets` to detect gaps. MCP `run_test_target` deliberately builds the
+actual CMake target and therefore also works for a current test without a dedicated preset.
+
+For the complete unit-test suite, prefer MCP `run_all_tests`; it builds all current `*_test.cpp` targets instead of
+trusting a potentially stale enumeration. The CI-intended preset flow is:
+
+```sh
+cmake --build --preset tests
+ctest --preset tests --output-on-failure
+```
+
+If that build preset reports a missing target, do not hide the failure. Use `run_all_tests` (or direct targets from
+`list_test_targets`) and report the preset drift separately.
+
+Use the named GCC, Clang, release, examples, or benchmark presets only when relevant to the change. Fuzz targets are
+Clang-only when `FUZZ_TESTS` is enabled. A benchmark run is performance evidence, not a correctness test.
+
+Always run real verification after code or build-system changes. Documentation-only and AI-configuration changes must
+still run their own format, parse, type-check, or smoke validation. Do not claim a command passed without its real exit
+status. If dependencies, compiler support, network access, or time prevents a check, report the exact command and
+reason.
+
+## Review and Handoff
+
+Before finishing:
+
+- Confirm the diff contains only intended files.
+- State what changed and why.
+- List the exact verification commands and results.
+- Call out unverified platforms, standards edge cases, or compatibility risks.
+- Do not commit, push, or open a pull request unless the user asks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# Claude Code Instructions for Web++
+
+Read and follow `AGENTS.md` before working in this repository. It is the canonical project guide; this file only adds
+Claude-specific operating instructions.
+
+## Repository Context
+
+This is the Web++ C++ web framework, not a CMS. Public implementation is predominantly in `.hpp` files under `webpp/`.
+There is no `src/` tree and no C++ modules architecture. Tests are under `tests/` and are mapped to CMake targets such
+as `tests/uri_test.cpp` -> `test-uri`.
+
+When prose conflicts with code, tests, CMake, or CI, follow the source-of-truth order in `AGENTS.md`. In particular,
+some component documentation openly warns that it is incomplete or outdated.
+
+## Use the Project MCP Server
+
+The repository's `.mcp.json` registers the `webpp-project` server from `mcp/`.
+
+At the start of a coding task:
+
+1. Use `project_overview`.
+2. Use `git_status`.
+3. Use `read_project_docs` for the affected subsystem.
+4. Use `search_project` and `read_project_file` to inspect implementation and tests.
+
+For verification, prefer `list_cmake_presets`, `run_cmake_configure`, `run_test_target`, `run_all_tests`,
+`run_cmake_build`, and `run_ctest`. `run_test_target` and `run_all_tests` discover current test files and avoid relying
+on stale, manually enumerated test presets. End by checking `git_status` and `git_diff`.
+
+If `webpp-project` is not connected, continue with equivalent shell commands rather than guessing. Mention the missing
+connection in the final report.
+
+## Claude Working Rules
+
+- Do not modify files before inspecting the nearest implementation and test.
+- Keep changes scoped; do not modernize or rename unrelated code.
+- Preserve C++20 compatibility for public library headers and the traits/allocator/character-type contracts.
+- Do not replace `webpp::stl` compatibility aliases or `webpp::istl` boundaries without a specific reason.
+- Treat URI, Unicode, IDNA, HTTP, and IP changes as standards-sensitive.
+- Review the complete diff before reporting completion.
+- Never claim build or test success without running the command.
+- Do not commit, push, or create a pull request unless explicitly requested.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,42 @@
+# Web++ Project MCP Server
+
+`webpp-project` is a repository-local MCP server for AI assistants working on Web++. It exposes safe, project-aware
+tools instead of generic shell access.
+
+## What It Knows
+
+- The real Web++ layout under `webpp/`, `tests/`, `examples/`, `benchmarks/`, `sdk/`, and `cmake/`
+- Component documentation for HTTP, URI, Unicode, traits/allocators, I/O, storage, middleware, and the SDK
+- Configure, build, and test presets from `CMakePresets.json`
+- The mapping from `tests/*_test.cpp` files to focused `test-*` targets
+- Detection of missing or stale focused test presets
+- Safe repository search, file reads, Git status/diff, configuration, builds, and CTest execution
+
+`run_test_target` and `run_all_tests` build targets discovered from current test sources. They remain usable when the
+manually enumerated focused presets have drifted from `tests/`.
+
+The server rejects reads outside the repository, Git internals, build output, dependencies, environment files, and
+common private-key formats. Commands run without a shell and are restricted to `git`, `rg`, `cmake`, and `ctest`.
+
+## Setup
+
+Install dependencies once:
+
+```sh
+npm --prefix mcp install
+```
+
+Type-check the server:
+
+```sh
+npm --prefix mcp run check
+```
+
+The root `.mcp.json` starts the server for clients that support project MCP configuration. The project root defaults to
+the parent of `mcp/`; it can be overridden with `PROJECT_ROOT`.
+
+Run it directly over stdio with:
+
+```sh
+npm --prefix mcp start
+```

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1728 @@
+{
+  "name": "webpp-project-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "webpp-project-mcp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.0",
+        "zod": "^3.25.76"
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "webpp-project-mcp",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/server.ts",
+    "check": "tsc -p tsconfig.json --noEmit",
+    "build": "npm run check",
+    "start": "tsx src/server.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.8.3"
+  }
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,700 @@
+import { spawn } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const thisFile = fileURLToPath(import.meta.url);
+const defaultProjectRoot = path.resolve(path.dirname(thisFile), "../..");
+const projectRoot = path.resolve(process.env.PROJECT_ROOT ?? defaultProjectRoot);
+const maxReadableBytes = 512 * 1024;
+const commandOutputLimit = 1024 * 1024;
+
+const allowedCommands = new Set(["git", "cmake", "ctest", "rg"]);
+const documentationGroups = {
+  overview: ["README.md", "webpp/README.md", "docs/index.md"],
+  http: ["webpp/http/README.md", "webpp/headers/README.md", "webpp/http/bodies/README.md"],
+  uri: ["webpp/uri/README.md"],
+  unicode: ["webpp/unicode/README.md", "webpp/unicode/details/README.md"],
+  traits: ["webpp/traits/README.md", "webpp/std/README.md", "webpp/memory/README.md"],
+  io: ["webpp/io/README.md"],
+  storage: ["webpp/storage/README.md"],
+  middleware: ["webpp/middleware/README.md"],
+  sdk: ["sdk/README.md"],
+  benchmarks: ["benchmarks/README.md"]
+} as const;
+
+const searchAreas = {
+  repository: ".",
+  library: "webpp",
+  tests: "tests",
+  docs: "docs",
+  examples: "examples",
+  benchmarks: "benchmarks",
+  sdk: "sdk",
+  cmake: "cmake"
+} as const;
+
+type CommandResult = {
+  command: string;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+};
+
+type NamedPreset = {
+  name?: string;
+  hidden?: boolean;
+  binaryDir?: string;
+  configurePreset?: string;
+  inherits?: string | string[];
+  targets?: string | string[];
+};
+
+type CMakePresets = {
+  configurePresets?: NamedPreset[];
+  buildPresets?: NamedPreset[];
+  testPresets?: NamedPreset[];
+};
+
+function textResponse(text: string) {
+  return {
+    content: [{ type: "text" as const, text }]
+  };
+}
+
+function isInsideRoot(resolvedPath: string): boolean {
+  const relative = path.relative(projectRoot, resolvedPath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function relativeProjectPath(resolvedPath: string): string {
+  return path.relative(projectRoot, resolvedPath).replaceAll(path.sep, "/");
+}
+
+function resolveInsideProject(inputPath: string): string {
+  if (inputPath.trim() === "") {
+    throw new Error("Path is required.");
+  }
+  if (inputPath.includes("\0")) {
+    throw new Error("Path contains a null byte.");
+  }
+
+  const resolved = path.resolve(projectRoot, inputPath);
+  if (!isInsideRoot(resolved)) {
+    throw new Error("Path is outside the repository root.");
+  }
+  return resolved;
+}
+
+function isGeneratedTopLevel(name: string): boolean {
+  return name === "build" || name.startsWith("build-") || name.startsWith("cmake-build-");
+}
+
+function rejectUnsafeReadPath(resolvedPath: string): void {
+  const relative = relativeProjectPath(resolvedPath);
+  const parts = relative.split("/").filter(Boolean);
+  const basename = path.basename(relative).toLowerCase();
+  const lowerRelative = relative.toLowerCase();
+
+  if (parts.includes(".git") || lowerRelative.startsWith(".git/")) {
+    throw new Error("Reading .git internals is not allowed.");
+  }
+  if (parts[0] && isGeneratedTopLevel(parts[0])) {
+    throw new Error("Reading build artifacts is not allowed.");
+  }
+  if (parts.includes("node_modules")) {
+    throw new Error("Reading node_modules is not allowed.");
+  }
+  if (parts[0] === "mcp" && parts[1] === "dist") {
+    throw new Error("Reading mcp/dist is not allowed.");
+  }
+  if (basename === ".env" || basename.startsWith(".env.")) {
+    throw new Error("Reading .env files is not allowed.");
+  }
+  if (
+    basename.includes("secret") ||
+    basename.includes("private") ||
+    basename === "id_rsa" ||
+    basename === "id_ed25519" ||
+    basename.endsWith(".pem") ||
+    basename.endsWith(".key") ||
+    basename.endsWith(".p12") ||
+    basename.endsWith(".pfx")
+  ) {
+    throw new Error("Reading secrets or private keys is not allowed.");
+  }
+}
+
+async function readProjectFileText(inputPath: string): Promise<string> {
+  const resolved = resolveInsideProject(inputPath);
+  rejectUnsafeReadPath(resolved);
+
+  const stat = await fs.stat(resolved);
+  if (!stat.isFile()) {
+    throw new Error("Path is not a regular file.");
+  }
+  if (stat.size > maxReadableBytes) {
+    throw new Error(`File is larger than ${maxReadableBytes} bytes.`);
+  }
+
+  return fs.readFile(resolved, "utf8");
+}
+
+function formatCommand(command: string, args: string[]): string {
+  return [command, ...args].map((part) => (/\s/.test(part) ? JSON.stringify(part) : part)).join(" ");
+}
+
+function formatCommandResult(result: CommandResult): string {
+  const truncated = result.truncated ? "\n[output truncated]" : "";
+  return [
+    `$ ${result.command}`,
+    `exit_code: ${result.exitCode ?? "unknown"}`,
+    "",
+    "stdout:",
+    result.stdout || "(empty)",
+    "",
+    "stderr:",
+    result.stderr || "(empty)",
+    truncated
+  ].join("\n");
+}
+
+async function runAllowedCommand(command: string, args: string[]): Promise<CommandResult> {
+  if (!allowedCommands.has(command)) {
+    throw new Error(`Command is not allowed: ${command}`);
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd: projectRoot,
+      env: process.env,
+      shell: false
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let truncated = false;
+
+    const append = (current: string, chunk: Buffer): string => {
+      if (current.length >= commandOutputLimit) {
+        truncated = true;
+        return current;
+      }
+      const next = current + chunk.toString("utf8");
+      if (next.length > commandOutputLimit) {
+        truncated = true;
+        return next.slice(0, commandOutputLimit);
+      }
+      return next;
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout = append(stdout, chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr = append(stderr, chunk);
+    });
+    child.on("error", (error) => {
+      stderr = append(stderr, Buffer.from(String(error)));
+    });
+    child.on("close", (exitCode) => {
+      resolve({
+        command: formatCommand(command, args),
+        exitCode,
+        stdout,
+        stderr,
+        truncated
+      });
+    });
+  });
+}
+
+async function pathExists(inputPath: string): Promise<boolean> {
+  try {
+    await fs.access(inputPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listExisting(paths: readonly string[]): Promise<string[]> {
+  const existing: string[] = [];
+  for (const item of paths) {
+    if (await pathExists(path.join(projectRoot, item))) {
+      existing.push(item);
+    }
+  }
+  return existing;
+}
+
+async function shallowTree(directory: string, depth = 0, maxDepth = 2): Promise<string[]> {
+  if (depth > maxDepth) {
+    return [];
+  }
+
+  const resolved = path.join(projectRoot, directory);
+  const entries = await fs.readdir(resolved, { withFileTypes: true });
+  const visible = entries
+    .filter((entry) => {
+      const relative = `${directory}/${entry.name}`.replace(/^\.\//, "");
+      const parts = relative.split("/");
+      return (
+        entry.name !== ".git" &&
+        entry.name !== ".DS_Store" &&
+        entry.name !== "node_modules" &&
+        entry.name !== "dist" &&
+        !(parts[0] && isGeneratedTopLevel(parts[0]))
+      );
+    })
+    .sort((left, right) => {
+      if (left.isDirectory() !== right.isDirectory()) {
+        return left.isDirectory() ? -1 : 1;
+      }
+      return left.name.localeCompare(right.name);
+    });
+
+  const lines: string[] = [];
+  for (const entry of visible) {
+    const relative = path.posix.join(directory === "." ? "" : directory, entry.name);
+    lines.push(`${"  ".repeat(depth)}${entry.isDirectory() ? `${relative}/` : relative}`);
+    if (entry.isDirectory()) {
+      lines.push(...(await shallowTree(relative, depth + 1, maxDepth)));
+    }
+  }
+  return lines;
+}
+
+async function readCMakePresets(): Promise<CMakePresets> {
+  const content = await readProjectFileText("CMakePresets.json");
+  return JSON.parse(content) as CMakePresets;
+}
+
+function presetNames(presets: NamedPreset[] | undefined, includeHidden = false): string[] {
+  return (
+    presets
+      ?.filter((preset) => includeHidden || !preset.hidden)
+      .map((preset) => preset.name)
+      .filter((name): name is string => Boolean(name)) ?? []
+  );
+}
+
+function ensurePresetExists(presets: NamedPreset[] | undefined, name: string, kind: string): void {
+  if (!presetNames(presets, true).includes(name)) {
+    throw new Error(`${kind} preset does not exist: ${name}`);
+  }
+}
+
+function expandPresetPath(inputPath: string): string {
+  return inputPath
+    .replaceAll("${sourceDir}", projectRoot)
+    .replaceAll("${sourceParentDir}", path.dirname(projectRoot))
+    .replaceAll("${sourceDirName}", path.basename(projectRoot));
+}
+
+function resolveSafeBuildDir(inputPath: string): string {
+  const resolved = resolveInsideProject(inputPath);
+  const relative = relativeProjectPath(resolved);
+  const topLevel = relative.split("/")[0];
+  if (!topLevel || !isGeneratedTopLevel(topLevel)) {
+    throw new Error("Build directory must be a top-level build/ or build-* / cmake-build-* path.");
+  }
+  return resolved;
+}
+
+function inheritedPresetNames(preset: NamedPreset): string[] {
+  if (!preset.inherits) {
+    return [];
+  }
+  return Array.isArray(preset.inherits) ? preset.inherits : [preset.inherits];
+}
+
+function findConfigureBinaryDir(presets: CMakePresets, presetName: string, visited = new Set<string>()): string | undefined {
+  if (visited.has(presetName)) {
+    throw new Error(`Circular configure preset inheritance involving: ${presetName}`);
+  }
+  visited.add(presetName);
+
+  const preset = presets.configurePresets?.find((candidate) => candidate.name === presetName);
+  if (!preset) {
+    return undefined;
+  }
+  if (preset.binaryDir) {
+    return preset.binaryDir;
+  }
+  for (const inheritedName of inheritedPresetNames(preset)) {
+    const inheritedBinaryDir = findConfigureBinaryDir(presets, inheritedName, visited);
+    if (inheritedBinaryDir) {
+      return inheritedBinaryDir;
+    }
+  }
+  return undefined;
+}
+
+function resolveConfigureBuildDir(presets: CMakePresets, presetName: string): string {
+  ensurePresetExists(presets.configurePresets, presetName, "Configure");
+  const binaryDir = findConfigureBinaryDir(presets, presetName);
+  if (!binaryDir) {
+    throw new Error(`Configure preset has no resolvable binaryDir: ${presetName}`);
+  }
+  return resolveSafeBuildDir(expandPresetPath(binaryDir));
+}
+
+function escapeRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function listTestTargets(): Promise<string[]> {
+  const entries = await fs.readdir(path.join(projectRoot, "tests"), { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith("_test.cpp"))
+    .map((entry) => `test-${entry.name.slice(0, -"_test.cpp".length).replaceAll("_", "-")}`)
+    .sort();
+}
+
+function formatPresetGroup(title: string, presets: NamedPreset[] | undefined): string[] {
+  const visible = presets?.filter((preset) => !preset.hidden) ?? [];
+  return [
+    `${title}:`,
+    ...visible.map((preset) => {
+      const targets = Array.isArray(preset.targets) ? preset.targets.join(", ") : preset.targets;
+      const details = [
+        preset.configurePreset ? `configure=${preset.configurePreset}` : "",
+        targets ? `targets=${targets}` : ""
+      ].filter(Boolean);
+      return `- ${preset.name ?? "(unnamed)"}${details.length > 0 ? ` (${details.join("; ")})` : ""}`;
+    })
+  ];
+}
+
+const server = new McpServer({
+  name: "webpp-project",
+  version: "1.0.0"
+});
+
+server.tool(
+  "project_overview",
+  "Describe the actual Web++ repository layout, authoritative files, major library subsystems, tests, and CMake entry points.",
+  {},
+  async () => {
+    const importantFiles = await listExisting([
+      "README.md",
+      "webpp/README.md",
+      "CMakeLists.txt",
+      "CMakePresets.json",
+      "webpp/CMakeLists.txt",
+      "tests/CMakeLists.txt",
+      ".clang-format",
+      ".clang-tidy",
+      "AGENTS.md",
+      "CLAUDE.md",
+      ".mcp.json"
+    ]);
+    const sourceFolders = await listExisting([
+      "webpp/http",
+      "webpp/uri",
+      "webpp/unicode",
+      "webpp/traits",
+      "webpp/memory",
+      "webpp/io",
+      "webpp/storage",
+      "webpp/protocol",
+      "sdk"
+    ]);
+    const developmentFolders = await listExisting(["tests", "examples", "benchmarks", "cmake", "docs", "mcp"]);
+    const tree = await shallowTree(".");
+
+    return textResponse(
+      [
+        "project: Web++ cross-platform C++ web framework",
+        `project_root: ${projectRoot}`,
+        "library_layout: predominantly template/header implementation under webpp/, exposed as a CMake static target",
+        "language_baseline: C++20 for the library; tests and GCC development targets may use C++23",
+        "authority: implementation/tests > CMake/CI > component docs > old prose/examples",
+        "",
+        "important_files:",
+        ...importantFiles.map((item) => `- ${item}`),
+        "",
+        "major_subsystems:",
+        ...sourceFolders.map((item) => `- ${item}`),
+        "",
+        "development_folders:",
+        ...developmentFolders.map((item) => `- ${item}`),
+        "",
+        "shallow_tree:",
+        ...tree.map((item) => `- ${item}`)
+      ].join("\n")
+    );
+  }
+);
+
+server.tool(
+  "read_project_file",
+  "Safely read a UTF-8 text file inside the Web++ repository, excluding build output, dependencies, Git internals, and secrets.",
+  {
+    path: z.string().min(1).describe("Repository-relative path to read.")
+  },
+  async ({ path: filePath }) => {
+    const content = await readProjectFileText(filePath);
+    return textResponse(`file: ${relativeProjectPath(resolveInsideProject(filePath))}\n\n${content}`);
+  }
+);
+
+server.tool(
+  "read_project_docs",
+  "Read the checked-in Web++ documentation for one subsystem. Some prose is stale; compare it with implementation and tests.",
+  {
+    topic: z
+      .enum([
+        "overview",
+        "http",
+        "uri",
+        "unicode",
+        "traits",
+        "io",
+        "storage",
+        "middleware",
+        "sdk",
+        "benchmarks"
+      ])
+      .default("overview")
+      .describe("Documentation group to read.")
+  },
+  async ({ topic }) => {
+    const files = documentationGroups[topic];
+    const sections: string[] = [];
+    for (const file of files) {
+      if (await pathExists(path.join(projectRoot, file))) {
+        sections.push(`## ${file}\n\n${await readProjectFileText(file)}`);
+      } else {
+        sections.push(`## ${file}\n\nMISSING`);
+      }
+    }
+    return textResponse(sections.join("\n\n---\n\n"));
+  }
+);
+
+server.tool(
+  "search_project",
+  "Search Web++ source, tests, docs, examples, SDK, benchmarks, or CMake files with ripgrep.",
+  {
+    query: z.string().min(1).max(500).describe("Literal or regular-expression pattern accepted by ripgrep."),
+    area: z
+      .enum(["repository", "library", "tests", "docs", "examples", "benchmarks", "sdk", "cmake"])
+      .default("repository")
+      .describe("Repository area to search."),
+    glob: z.string().min(1).max(200).optional().describe("Optional ripgrep glob such as '*.hpp'.")
+  },
+  async ({ query, area, glob }) => {
+    const args = [
+      "-n",
+      "--hidden",
+      "--glob",
+      "!.git/**",
+      "--glob",
+      "!mcp/node_modules/**",
+      "--glob",
+      "!build*/**",
+      "--glob",
+      "!cmake-build-*/**"
+    ];
+    if (glob) {
+      args.push("--glob", glob);
+    }
+    args.push("--", query, searchAreas[area]);
+    return textResponse(formatCommandResult(await runAllowedCommand("rg", args)));
+  }
+);
+
+server.tool("git_status", "Run git status --short for the Web++ worktree.", {}, async () => {
+  return textResponse(formatCommandResult(await runAllowedCommand("git", ["status", "--short"])));
+});
+
+server.tool(
+  "git_diff",
+  "Run git diff for tracked Web++ changes, or git diff --staged when staged is true.",
+  {
+    staged: z.boolean().default(false).describe("Return the staged diff instead of the working-tree diff.")
+  },
+  async ({ staged }) => {
+    const args = staged ? ["diff", "--staged"] : ["diff"];
+    return textResponse(formatCommandResult(await runAllowedCommand("git", args)));
+  }
+);
+
+server.tool(
+  "list_cmake_presets",
+  "List usable Web++ configure, build, and test presets from CMakePresets.json.",
+  {},
+    async () => {
+      const presets = await readCMakePresets();
+      const testTargets = await listTestTargets();
+      const buildPresetNames = new Set(presetNames(presets.buildPresets, true));
+      const testPresetNames = new Set(
+        presetNames(presets.buildPresets, true).filter((name) => name.startsWith("test-"))
+      );
+      const missingFocusedPresets = testTargets.filter((target) => !buildPresetNames.has(target));
+      const staleFocusedPresets = [...testPresetNames].filter((target) => !testTargets.includes(target));
+      return textResponse(
+        [
+          ...formatPresetGroup("configure_presets", presets.configurePresets),
+        "",
+          ...formatPresetGroup("build_presets", presets.buildPresets),
+          "",
+          ...formatPresetGroup("test_presets", presets.testPresets),
+          "",
+          "focused_test_preset_gaps:",
+          ...(missingFocusedPresets.length > 0 ? missingFocusedPresets.map((name) => `- ${name}`) : ["- none"]),
+          "",
+          "stale_focused_test_presets:",
+          ...(staleFocusedPresets.length > 0 ? staleFocusedPresets.map((name) => `- ${name}`) : ["- none"])
+        ].join("\n")
+      );
+    }
+);
+
+server.tool(
+  "list_test_targets",
+  "List focused CMake/CTest target names derived from current tests/*_test.cpp files and show whether each has a build preset.",
+  {},
+  async () => {
+    const presets = await readCMakePresets();
+    const buildPresetNames = new Set(presetNames(presets.buildPresets, true));
+    return textResponse(
+      (await listTestTargets())
+        .map((target) => `- ${target} (${buildPresetNames.has(target) ? "preset" : "direct CMake target"})`)
+        .join("\n")
+    );
+  }
+);
+
+server.tool(
+  "run_cmake_configure",
+  "Run cmake --preset for a validated Web++ configure preset. CI development configuration is dev-default.",
+  {
+    preset: z.string().min(1).default("dev-default").describe("Configure preset from CMakePresets.json.")
+  },
+  async ({ preset }) => {
+    const presets = await readCMakePresets();
+    ensurePresetExists(presets.configurePresets, preset, "Configure");
+    return textResponse(formatCommandResult(await runAllowedCommand("cmake", ["--preset", preset])));
+  }
+);
+
+server.tool(
+  "run_cmake_build",
+  "Build a validated Web++ build preset, such as a focused test target, tests, examples, or benchmarks.",
+  {
+    preset: z.string().min(1).describe("Build preset from CMakePresets.json.")
+  },
+  async ({ preset }) => {
+    const presets = await readCMakePresets();
+    ensurePresetExists(presets.buildPresets, preset, "Build");
+    return textResponse(formatCommandResult(await runAllowedCommand("cmake", ["--build", "--preset", preset])));
+  }
+);
+
+server.tool(
+  "run_ctest",
+  "Run a validated Web++ CTest preset, optionally filtering to one or more test names.",
+  {
+    preset: z.string().min(1).default("tests").describe("CTest preset from CMakePresets.json."),
+    filter: z.string().min(1).max(500).optional().describe("Optional CTest -R regular expression.")
+  },
+  async ({ preset, filter }) => {
+    const presets = await readCMakePresets();
+    ensurePresetExists(presets.testPresets, preset, "Test");
+    const args = ["--preset", preset, "--output-on-failure"];
+    if (filter) {
+      args.push("-R", filter);
+    }
+    return textResponse(formatCommandResult(await runAllowedCommand("ctest", args)));
+  }
+);
+
+server.tool(
+  "run_test_target",
+  "Build and run one current Web++ test target derived from tests/*_test.cpp, including tests without a dedicated preset.",
+  {
+    target: z.string().min(1).describe("Focused test target returned by list_test_targets."),
+    configurePreset: z
+      .string()
+      .min(1)
+      .default("dev-default")
+      .describe("Configure preset whose build directory should be used.")
+  },
+  async ({ target, configurePreset }) => {
+    const testTargets = await listTestTargets();
+    if (!testTargets.includes(target)) {
+      throw new Error(`Focused test target does not exist: ${target}`);
+    }
+
+    const presets = await readCMakePresets();
+    const buildDir = resolveConfigureBuildDir(presets, configurePreset);
+
+    const build = await runAllowedCommand("cmake", ["--build", buildDir, "--target", target]);
+    if (build.exitCode !== 0) {
+      return textResponse(formatCommandResult(build));
+    }
+
+    const test = await runAllowedCommand("ctest", [
+      "--test-dir",
+      buildDir,
+      "--output-on-failure",
+      "-R",
+      `^${escapeRegularExpression(target)}$`
+    ]);
+    return textResponse(`${formatCommandResult(build)}\n\n${formatCommandResult(test)}`);
+  }
+);
+
+server.tool(
+  "run_all_tests",
+  "Build every current tests/*_test.cpp target and run the complete CTest suite without relying on the manually enumerated tests build preset.",
+  {
+    configurePreset: z
+      .string()
+      .min(1)
+      .default("dev-default")
+      .describe("Configure preset whose build directory should be used.")
+  },
+  async ({ configurePreset }) => {
+    const presets = await readCMakePresets();
+    const buildDir = resolveConfigureBuildDir(presets, configurePreset);
+    const testTargets = await listTestTargets();
+    const build = await runAllowedCommand("cmake", ["--build", buildDir, "--target", ...testTargets]);
+    if (build.exitCode !== 0) {
+      return textResponse(formatCommandResult(build));
+    }
+
+    const test = await runAllowedCommand("ctest", ["--test-dir", buildDir, "--output-on-failure"]);
+    return textResponse(`${formatCommandResult(build)}\n\n${formatCommandResult(test)}`);
+  }
+);
+
+server.tool(
+  "resolve_build_directory",
+  "Resolve and validate the build directory associated with a Web++ configure preset.",
+  {
+    preset: z.string().min(1).default("dev-default").describe("Configure preset from CMakePresets.json.")
+  },
+    async ({ preset }) => {
+      const presets = await readCMakePresets();
+      const resolved = resolveConfigureBuildDir(presets, preset);
+      return textResponse(`preset: ${preset}\nbuild_directory: ${relativeProjectPath(resolved)}`);
+    }
+  );
+
+async function main(): Promise<void> {
+  await server.connect(new StdioServerTransport());
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": false,
+    "types": ["node"],
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

This PR replaces the generic and outdated AI instructions with project-aware guidance tailored specifically to Web++.

New configuration reflects the actual Web++ codebase, its CMake workflow, compatibility requirements, and subsystem boundaries.

## Changes

- Added `AGENTS.md` as the canonical AI contributor guide
- Added `CLAUDE.md` with Claude-specific workflow instructions
- Added MCP server with `webpp-project`
- Added project-aware MCP tools for:
  - repository discovery and documentation
  - source-code search and safe file reads
  - Git status and diff inspection
  - CMake preset discovery
  - focused and complete test execution
- Added `.mcp.json` for repository-local MCP configuration
- Added MCP setup and usage documentation
- Updated `.gitignore` for MCP dependencies, generated output, and macOS metadata

## Project-Specific Guidance

The new instructions account for:

- Web++'s predominantly header-based implementation under `webpp/`
- C++20 compatibility for public library code
- C++23 usage in development and test targets where configured
- traits, allocator, character-type, and `webpp::stl` compatibility boundaries
- constexpr-heavy routing and concepts-based contracts
- standards-sensitive URI, Unicode, IDNA, HTTP, and IP behavior
- the actual relationship between test files, CMake targets, and presets

## Additional Finding

The MCP server detects drift between current test sources and manually maintained focused-test presets.

Currently:

- five existing test targets do not have dedicated build presets
- five focused presets refer to test sources that no longer exist

This PR does not modify `CMakePresets.json`, but the MCP test tools discover targets directly from `tests/*_test.cpp`, allowing focused and complete verification despite that drift.

## Validation

- TypeScript type-check passed
- MCP and package JSON files parsed successfully
- CMake and CTest presets parsed successfully
- MCP connection and tool discovery smoke test passed
- Project overview, test discovery, preset-drift detection, and build-directory resolution were exercised through an MCP client
- `git diff --check` passed

No C++ implementation was changed, so the C++ test suite was not rebuilt.